### PR TITLE
disable clustering map results

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -58,7 +58,7 @@ define(function(require, exports, module) {
 
       if (mapConfig.maxZoom){
         this.map.options.maxZoom = mapConfig.maxZoom;
-        this.cluster.options.disableClusteringAtZoom = mapConfig.maxZoom;
+        this.cluster.options.disableClusteringAtZoom = 1;
         this.cluster._maxZoom = mapConfig.maxZoom - 1;
       }
       if (mapConfig.maxBounds){


### PR DESCRIPTION
fixes #21 

I would prefer that clustering be a configuration option, but this seems to turn it off. 

Old
![screen shot 2015-10-10 at 10 22 55 pm](https://cloud.githubusercontent.com/assets/7292/10414336/81c43fd6-6f9d-11e5-96ef-5d452f7313b6.png)

New
![screen shot 2015-10-10 at 10 19 15 pm](https://cloud.githubusercontent.com/assets/7292/10414333/0f7114ae-6f9d-11e5-800a-36bafc794527.png)
