### PR TITLE
Use Bootstrap tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,6 @@
       <div class="container-fluid">
          <!--Brand and Toggle get grouped for better mobile display-->
         <div class="navbar-header">
-         <!-- <button type="button" class="navbar&#45;toggle" data&#45;toggle="collapse" data&#45;target="#finda&#45;navbar&#45;collapse"> -->
-         <!--   <span class="sr&#45;only">Toggle Navigation</span> -->
-         <!--   <span class="icon&#45;bar"></span> -->
-         <!--   <span class="icon&#45;bar"></span> -->
-         <!--   <span class="icon&#45;bar"></span> -->
-         <!-- </button> -->
          <a class="navbar-brand" data-project="name" href="">Get Help Kentucky</a> <!-- This is the name of the map -->
          <img src="img/spinner.gif" id="message" style="display:none;" width="20px">
         </div>
@@ -47,10 +41,12 @@
     </nav>
 
     <div class="container">
-      <ul class="nav nav-tabs control-tabs">
-        <li role="presentation" class="active"><a data-toggle="tab" href="#facets" id="facet-click">Get Started</a></li>
-        <li role="presentation"><a data-toggle="tab" id="results-tab" href="#list">View Facilities</a></li>
-      </ul>
+      <nav id="finda-tabs">
+        <ul class="nav nav-tabs survey-tabs control-tabs">
+          <li role="presentation" class="active"><a data-toggle="tab" href="#facets" id="facet-click">Get Started</a></li>
+          <li role="presentation"><a data-toggle="tab" id="results-tab" href="#list">View Facilities</a></li>
+        </ul>
+      </nav>
 
       <div class="tab-content">
         <div id="facets" class="tab-pane control control-survey active"></div>

--- a/index.html
+++ b/index.html
@@ -47,12 +47,16 @@
     </nav>
 
     <div class="container">
-      <div id="facets" class="control control-survey"></div>
-      <div id="list" style="display:none" class="control control-sidebar"></div>
+      <ul class="nav nav-tabs control-tabs">
+        <li role="presentation" class="active"><a data-toggle="tab" href="#facets" id="facet-click">Get Started</a></li>
+        <li role="presentation"><a data-toggle="tab" id="results-tab" href="#list">View Facilities</a></li>
+      </ul>
+
+      <div class="tab-content">
+        <div id="facets" class="tab-pane control control-survey active"></div>
+        <div id="list" class="tab-pane control control-sidebar"></div>
+      </div>
       <div id="map" style="display:none"></div>
-      <!-- <div id="info" class="control"> -->
-      <!--   <button type="button" class="close">&#38;times;</button> -->
-      <!-- </div> -->
     </div>
 
     <div class="modal fade" id="about" tabindex="-1" role="dialog" aria-labelledby="aboutLabel" aria-hidden="true">

--- a/src/infotemplates.js
+++ b/src/infotemplates.js
@@ -11,7 +11,7 @@ define(function(require, exports) {
     directions: Handlebars.compile('<a target="_blank" href="http://maps.google.com/maps?q={{directions}}">{{title}}</a>'),
     simple: Handlebars.compile('{{text}}'),
     phone_numbers: Handlebars.compile('<a href="tel:{{text}}">{{text}}</a>'),
-    popup: Handlebars.compile('<div>{{#popup}}<div class="feature-{{klass}}">{{{rendered}}}</div>{{/popup}}</div>')
+    popup: Handlebars.compile('<a id="{{featureId}}"></a><div>{{#popup}}<div class="feature-{{klass}}">{{{rendered}}}</div>{{/popup}}</div>')
   };
   var formatters = {
     url: function(value, property) {
@@ -80,10 +80,10 @@ define(function(require, exports) {
     return formatters[formatter](value, property);
   }
 
-  exports.popup = function(properties, feature) {
+  exports.popup = function(propertiesToRender, featureProperties, featureId) {
     var popup = [],
         rendered;
-    _.each(properties, function(property) {
+    _.each(propertiesToRender, function(property) {
 
       var key;
       if (typeof property === "string") {
@@ -92,7 +92,7 @@ define(function(require, exports) {
         key = property.name;
       }
 
-      var value = feature[key];
+      var value = featureProperties[key];
       if (value !== undefined && (value.length === undefined || value.length !== 0)) {
         rendered = format(value, property);
         if (rendered) {
@@ -103,6 +103,6 @@ define(function(require, exports) {
         }
       }
     });
-    return templates.popup({popup: popup});
+    return templates.popup({popup: popup, featureId: featureId});
   };
 });

--- a/src/infotemplates.js
+++ b/src/infotemplates.js
@@ -11,7 +11,7 @@ define(function(require, exports) {
     directions: Handlebars.compile('<a target="_blank" href="http://maps.google.com/maps?q={{directions}}">{{title}}</a>'),
     simple: Handlebars.compile('{{text}}'),
     phone_numbers: Handlebars.compile('<a href="tel:{{text}}">{{text}}</a>'),
-    popup: Handlebars.compile('<a id="{{featureId}}"></a><div>{{#popup}}<div class="feature-{{klass}}">{{{rendered}}}</div>{{/popup}}</div>')
+    popup: Handlebars.compile('<a id="{{featureId}}">&nbsp;</a><div>{{#popup}}<div class="feature-{{klass}}">{{{rendered}}}</div>{{/popup}}</div>')
   };
   var formatters = {
     url: function(value, property) {

--- a/src/script.js
+++ b/src/script.js
@@ -43,6 +43,7 @@ define(function(require) {
   require('ui/search_results').attachTo('#search-results');
   require('ui/info').attachTo('#info');
   require('ui/list').attachTo('#list');
+  require('ui/tabs').attachTo('#finda-tabs');
   require('ui/facet').attachTo('#facets');
   require('ui/loading').attachTo('#loading');
   require('ui/filtering').attachTo('#message');

--- a/src/ui/facet.js
+++ b/src/ui/facet.js
@@ -53,7 +53,7 @@ define(function(require, exports, module) {
 
       // show first question if you're looking for a treatment facility
       if (this.facetOffset === -1) {
-        this.$node.html(templates.needTreatment()).show();
+        this.$node.html(templates.needTreatment());
         this.on('.js-next-prev', 'click', this.nextPrevHandler);
         this.on('.js-no-treatment', 'click', this.showNoTreatment);
         this.on('.js-not-sure-treatment', 'click', this.showNoTreatment);
@@ -116,7 +116,7 @@ define(function(require, exports, module) {
           showResults: this.showAllFacets,
           facetOffset: this.facetOffset + 1
         })
-      ).show();
+      );
 
       this.on('.js-next-prev', 'click', this.nextPrevHandler);
       this.on('.js-offer-results', 'click', this.showResultsHandler);

--- a/src/ui/list.js
+++ b/src/ui/list.js
@@ -41,7 +41,6 @@ define(function(require, exports, module) {
         return;
       }
       this.trigger('listStarted', {});
-      // this.$node.show();
       this.render = _.partial(templates.popup, config.list);
       this.renderFull = _.partial(templates.popup, config.properties);
     };
@@ -116,7 +115,8 @@ define(function(require, exports, module) {
         listItemSelector: this.onFeatureClick
       });
       this.on(document, 'uiShowResults', function() {
-        this.$node.show();
+        // this.$node.show();
+        $('#results-tab').click();
       });
       this.on(document, 'uiHideResults', function() {
         this.$node.hide();

--- a/src/ui/list.js
+++ b/src/ui/list.js
@@ -50,7 +50,7 @@ define(function(require, exports, module) {
       timedWithObject(
         data.features,
         function(feature, l) {
-          var $li = $("<li/>").html(this.render(feature.properties))
+          var $li = $("<li/>").html(this.render(feature.properties, feature.id))
                 .addClass('item')
                 .data('feature', feature);
           $li._text = $li.text();
@@ -83,10 +83,11 @@ define(function(require, exports, module) {
 
     this.onFeatureSelected = function onFeatureSelected(ev, feature) {
       var $selectedItem = $elementForFeature.call(this, feature);
-      var offset = $selectedItem.offset().top - 50;
       var propsWithTitles = this.addFacetTitles(feature.properties, this.facetTitles);
-      $selectedItem.html(this.renderFull(propsWithTitles));
-      this.scrollToOffset(offset);
+
+      // set url to blah.com#finda-17
+      window.location.hash = feature.id;
+      $selectedItem.html(this.renderFull(propsWithTitles, feature.id));
     };
 
     this.addFacetTitles = function(featureProperties, facetTitles) {
@@ -100,10 +101,6 @@ define(function(require, exports, module) {
         }
       }.bind(this));
       return propsWithTitles;
-    };
-
-    this.scrollToOffset = function(offset) {
-      this.$node.scrollTop(this.$node.scrollTop() + offset);
     };
 
     this.after('initialize', function() {

--- a/src/ui/list.js
+++ b/src/ui/list.js
@@ -88,6 +88,9 @@ define(function(require, exports, module) {
       // set url to blah.com#finda-17
       window.location.hash = feature.id;
       $selectedItem.html(this.renderFull(propsWithTitles, feature.id));
+
+      // does not clear previous selections so they remain findable later
+      $selectedItem.addClass('selected-facility');
     };
 
     this.addFacetTitles = function(featureProperties, facetTitles) {
@@ -110,10 +113,6 @@ define(function(require, exports, module) {
       this.on(document, 'selectFeature', this.onFeatureSelected);
       this.on('click', {
         listItemSelector: this.onFeatureClick
-      });
-      this.on(document, 'uiShowResults', function() {
-        // this.$node.show();
-        $('#results-tab').click();
       });
       this.on(document, 'uiHideResults', function() {
         this.$node.hide();

--- a/src/ui/tabs.js
+++ b/src/ui/tabs.js
@@ -1,0 +1,13 @@
+define(function(require, exports, module) {
+  'use strict';
+  var flight = require('flight');
+
+  module.exports = flight.component(function sidebar() {
+    this.after('initialize', function() {
+      this.on(document, 'uiShowResults', function() {
+        this.$node.find('#results-tab').click();
+        this.$node.find('.survey-tabs').removeClass('survey-tabs');
+      });
+    });
+  });
+});

--- a/styles/style.css
+++ b/styles/style.css
@@ -16,7 +16,7 @@ body {
 }
 
 body > div.container {
-  position: fixed;
+  position: relative;
   width: 100%;
   height: 100%;
   top: 50px;
@@ -187,9 +187,9 @@ body > div.container {
   float: left;
   box-sizing: border-box;
   padding: 10px 14px 50px;
-  width: 300px;
+  width: 600px;
   height: 100%;
-  border-right: 1px solid #AFAFAF;
+  border-right: 1px solid #ddd;
   margin-bottom: 30px;
   overflow-y: auto;
 }
@@ -284,14 +284,26 @@ body > div.container {
   box-sizing: border-box;
   padding: 10px 14px 50px;
   height: 100%;
-  border-right: 1px solid #AFAFAF;
-  border-left: 1px solid #AFAFAF;
+  border-right: 1px solid #ddd;
+  border-left: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
   margin-bottom: 30px;
   overflow-y: auto;
 }
 
 .control-survey .btn {
   margin-bottom: 5px
+}
+
+.control-tabs {
+  width: 80%;
+  margin: auto;
+}
+.nav-tabs.control-tabs>li.active>a {
+  background-color: #f3f3f3;
+  border-top: 1px solid #ddd;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
 }
 
 @media (max-width: 600px) {

--- a/styles/style.css
+++ b/styles/style.css
@@ -190,7 +190,6 @@ body > div.container {
   width: 600px;
   height: 100%;
   border-right: 1px solid #ddd;
-  margin-bottom: 30px;
   overflow-y: auto;
 }
 
@@ -269,6 +268,12 @@ body > div.container {
   content: "\b7\a0";
 }
 
+/* clear the navbar when anchored to in url */
+#list .selected-facility {
+  margin-top: 50px;
+  border-right: 20px solid #69579c;
+}
+
 #about .modal-footer img {
   height: 2.5em;
   float: left;
@@ -282,12 +287,11 @@ body > div.container {
   width: 80%;
   margin: auto;
   box-sizing: border-box;
-  padding: 10px 14px 50px;
+  padding: 10px 14px 20px;
   height: 100%;
   border-right: 1px solid #ddd;
   border-left: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
-  margin-bottom: 30px;
   overflow-y: auto;
 }
 
@@ -295,7 +299,7 @@ body > div.container {
   margin-bottom: 5px
 }
 
-.control-tabs {
+.survey-tabs {
   width: 80%;
   margin: auto;
 }
@@ -308,6 +312,7 @@ body > div.container {
 
 @media (max-width: 600px) {
   .control-survey,
+  .survey-tabs,
   .control-sidebar {
     width: 100%
   }

--- a/test/spec/ui/list_spec.js
+++ b/test/spec/ui/list_spec.js
@@ -15,14 +15,6 @@ define(
         });
       });
 
-      describe('on uiShowResults', function() {
-        it("makes the node visible", function() {
-          this.$node.css('display', 'none');
-          $(document).trigger('uiShowResults', mock.config);
-          expect(this.$node.css('display')).not.toEqual('none');
-        });
-      });
-
       describe('on data', function() {
         beforeEach(function() {
           $(document).trigger('config', mock.config);
@@ -39,7 +31,7 @@ define(
           var $li = this.$node.find('li:eq(0)');
           var feature = $li.data('feature');
           expect($li.html()).toEqual(
-            templates.popup(mock.config.list, feature.properties));
+            templates.popup(mock.config.list, feature.properties, feature.id));
         });
 
         it('sorts the list items by their text', function() {
@@ -76,14 +68,11 @@ define(
         });
 
         it('scrolls to the selected feature', function() {
-          spyOn(this.component, 'scrollToOffset');
-
           var $li = this.$node.find('li:eq(1)');
           var feature = $li.data('feature');
 
           $(document).trigger('selectFeature', feature);
-          expect(this.component.scrollToOffset).toHaveBeenCalledWith(
-            $li.offset().top - 50);
+          expect(window.location.hash).toBe('#' + feature.id);
         });
       });
     });


### PR DESCRIPTION
After looking into #14 and @isaacchansky's [nice PR](https://github.com/openlexington/finda/issues/14#issuecomment-147100892) I realized that Bootstrap tabs are a straightfoward way to unify the mobile and desktop views with minimal code upheaval.

The tradeoff will be getting the map to display in a Bootstrap tab for mobile views. From the usability testing so far, users are primarily concerned with the questionnaire/facets rather than the map so this seems good enough for more testing. 

I propose we use this for now so we can get feedback and determine the priority of the mobile map (#30).
