### PR TITLE
Feedback to spreadsheet, add disclaimer

### DIFF
--- a/google-apps-feedback-script.js
+++ b/google-apps-feedback-script.js
@@ -1,0 +1,76 @@
+// The Google Apps Script that you install in Google sheet to make it a feedback endpoint
+// based on:
+// https://mashe.hawksey.info/2014/07/google-sheets-as-a-database-insert-with-apps-script-using-postget-methods-with-ajax-example/
+
+//  1. Enter sheet name where data is to be written below
+        var SHEET_NAME = "Sheet1";
+
+//  2. Run > setup
+//
+//  3. Publish > Deploy as web app
+//    - enter Project Version name and click 'Save New Version'
+//    - set security level and enable service (most likely execute as 'me' and access 'anyone, even anonymously)
+//
+//  4. Copy the 'Current web app URL' and post this in your form/script action
+//
+//  5. Insert column names on your destination sheet matching the parameter names of the data you are passing in (exactly matching case)
+
+var SCRIPT_PROP = PropertiesService.getScriptProperties(); // new property service
+
+// If you don't want to expose either GET or POST methods you can comment out the appropriate function
+function doGet(e){
+  return handleResponse(e);
+}
+
+function doPost(e){
+  return handleResponse(e);
+}
+
+function handleResponse(e) {
+  // shortly after my original solution Google announced the LockService[1]
+  // this prevents concurrent access overwritting data
+  // [1] http://googleappsdeveloper.blogspot.co.uk/2011/10/concurrency-and-google-apps-script.html
+  // we want a public lock, one that locks for all invocations
+  var lock = LockService.getPublicLock();
+  lock.waitLock(30000);  // wait 30 seconds before conceding defeat.
+
+  try {
+    MailApp.sendEmail("person@domain.org", "[GetHelpLex feedback]", JSON.stringify(e.parameters));
+
+    // next set where we write the data - you could write to multiple/alternate destinations
+    var doc = SpreadsheetApp.openById(SCRIPT_PROP.getProperty("key"));
+    var sheet = doc.getSheetByName(SHEET_NAME);
+
+    // we'll assume header is in row 1 but you can override with header_row in GET/POST data
+    var headRow = e.parameter.header_row || 1;
+    var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    var nextRow = sheet.getLastRow()+1; // get next row
+    var row = [];
+    // loop through the header columns
+    for (i in headers){
+      if (headers[i] == "Timestamp"){ // special case if you include a 'Timestamp' column
+        row.push(new Date());
+      } else { // else use header name to get data
+        row.push(e.parameter[headers[i]]);
+      }
+    }
+    // more efficient to set values as [][] array than individually
+    sheet.getRange(nextRow, 1, 1, row.length).setValues([row]);
+    // return json success results
+    return ContentService
+          .createTextOutput(JSON.stringify({"result":"success", "row": nextRow}))
+          .setMimeType(ContentService.MimeType.JSON);
+  } catch(e){
+    // if error return this
+    return ContentService
+          .createTextOutput(JSON.stringify({"result":"error", "error": e}))
+          .setMimeType(ContentService.MimeType.JSON);
+  } finally { //release lock
+    lock.releaseLock();
+  }
+}
+
+function setup() {
+    var doc = SpreadsheetApp.getActiveSpreadsheet();
+    SCRIPT_PROP.setProperty("key", doc.getId());
+}

--- a/google-apps-feedback-script.js
+++ b/google-apps-feedback-script.js
@@ -1,4 +1,4 @@
-// The Google Apps Script that you install in Google sheet to make it a feedback endpoint
+// Copy of the Google Apps Script that you install in Google sheet to make it a feedback endpoint
 // based on:
 // https://mashe.hawksey.info/2014/07/google-sheets-as-a-database-insert-with-apps-script-using-postget-methods-with-ajax-example/
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
           </div>
           <div class="modal-body">
             <div><strong>Get Help Lex</strong> is a resource for people seeking facilities and services for substance use disorder (substance abuse/addiction) in and around Lexington, Kentucky. <a href="https://github.com/openlexington/finda">Get Help Lex</a> is an open-source project. GHL is an adaptation of Code for Boston's <a href="https://github.com/codeforboston/finda">Finda project</a>. The source code for both Finda and GHL are publically available on GitHub.</div>
-            <h5>Please send feedback, ideas, and bug reports to <a href="mailto:gethelplex@lexingtonky.gov?subject=Get Help Lex Feedback">gethelplex@lexingtonky.gov</a> page.</h5>
+            <h5>Please <a href="#" data-toggle="modal" data-target="#feedback-modal">send feedback, ideas, and bug reports here</a>.</h5>
 
             <hr>
 
@@ -135,9 +135,9 @@
             <div class="alert alert-danger js-error" style="display:none">We apologize, there was a problem sending the feedback. Please email <a class="js-error-email" href="#">gethelplex@lexingtonky.gov</a> instead.</div>
             A few things to remember:
             <ul>
-              <li>This is for feedback about this website, not for assessment or diagnosis</li>
-              <li>Please not to add any sensitive personal information</li>
               <li>If this is an emergency, please dial <a href="tel:911">911</a></li>
+              <li>This is not for assessment or diagnosis and is not always monitored</li>
+              <li>Please not to add any sensitive personal information</li>
             </ul>
             <form id="feedback-form" class="form-horizontal" action="#" role="form" method="post">
               <textarea id="feedback-text" class="form-control" aria-describedby="feedback-label"></textarea>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             <ul>
               <li>If this is an emergency, please dial <a href="tel:911">911</a></li>
               <li>This is not for assessment or diagnosis and is not always monitored</li>
-              <li>Please not to add any sensitive personal information</li>
+              <li>Please do not add any sensitive personal information</li>
             </ul>
             <form id="feedback-form" class="form-horizontal" action="#" role="form" method="post">
               <textarea id="feedback-text" class="form-control" aria-describedby="feedback-label"></textarea>

--- a/index.html
+++ b/index.html
@@ -131,16 +131,34 @@
             <h4 class="modal-title" id="myModalLabel">Send us your feedback!</h4>
           </div>
           <div class="modal-body">
-            <label id="feedback-label">
-              Anything missing, incorrect, or anything else?<br />
-              <em>Just remember not to add any sensitive personal information.</em>
-            </label>
+            <div class="alert alert-success js-thank-you" role="alert" style="display:none">Your feedback has been sent!</div>
+            <div class="alert alert-danger js-error" style="display:none">We apologize, there was a problem sending the feedback. Please email <a class="js-error-email" href="#">gethelplex@lexingtonky.gov</a> instead.</div>
+            A few things to remember:
+            <ul>
+              <li>This is for feedback about this website, not for assessment or diagnosis</li>
+              <li>Please not to add any sensitive personal information</li>
+              <li>If this is an emergency, please dial <a href="tel:911">911</a></li>
+            </ul>
             <form id="feedback-form" class="form-horizontal" action="#" role="form" method="post">
               <textarea id="feedback-text" class="form-control" aria-describedby="feedback-label"></textarea>
-              <button type="submit" class="btn btn-primary">Send</button>
+              <label><input type="checkbox" required="required"> I have read the
+              <a data-toggle="collapse" href="#feedback-disclaimer" aria-expanded="false" aria-controls="disclaimer">disclaimer</a></label>
+              <button type="submit" class="js-submit btn btn-primary">Send</button>
               <button type="button" class="btn btn-cancel">Cancel</button>
             </form>
-            <h3 class="thank-you" style="display:none">Your feedback has been sent!</h3>
+            <div class="collapse well" id="feedback-disclaimer">
+              <p>Get Help Lex is a tool to help you find a substance abuse treatment program for yourself or others. It's an informational tool ONLY. <strong>If you are experiencing a medical emergency, please call <a href="tel:911">911.</a></strong></p>
+
+              <p>Please remember that it is:</p>
+
+              <ul>
+                <li>NOT a diagnostic tool</li>
+                <li>NOT an assessment tool</li>
+                <li>NOT a substitute for substance use treatment services</li>
+              </ul>
+
+              <p><strong>No identifying information is being collected from your search.</strong></p>
+            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -141,8 +141,11 @@
             </ul>
             <form id="feedback-form" class="form-horizontal" action="#" role="form" method="post">
               <textarea id="feedback-text" class="form-control" aria-describedby="feedback-label"></textarea>
-              <label><input type="checkbox" required="required"> I have read the
-              <a data-toggle="collapse" href="#feedback-disclaimer" aria-expanded="false" aria-controls="disclaimer">disclaimer</a></label>
+              <div>
+                <label><input type="checkbox" required="required"> I have read the
+                  <a data-toggle="collapse" href="#feedback-disclaimer" aria-expanded="false" aria-controls="disclaimer">disclaimer</a>
+                </label>
+              </div>
               <button type="submit" class="js-submit btn btn-primary">Send</button>
               <button type="button" class="btn btn-cancel">Cancel</button>
             </form>

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ Kick off a test run when the test server is running:
 
 GetHelpLex uses Google Tag Manager to manage Google Analytics as described in the [Unified Analytics repository](https://github.com/laurenancona/unified-analytics).
 
-The feedback form is the [ga-feedback approach](https://github.com/luckyshot/ga-feedback) managed by Google Tag Manager [as described here](http://erikschwartz.net/2016-01-23-google-analytics-events-in-google-tag-manager/).
+GetHelpLex posts feedback to a Google Spreadsheet [as described here](https://mashe.hawksey.info/2014/07/google-sheets-as-a-database-insert-with-apps-script-using-postget-methods-with-ajax-example/).
+As a backup, feedback is tracked using the [ga-feedback approach](https://github.com/luckyshot/ga-feedback) managed by Google Tag Manager [as described here](http://erikschwartz.net/2016-01-23-google-analytics-events-in-google-tag-manager/).
 
 ## Add map coordinates for new facilities
 

--- a/src/script.js
+++ b/src/script.js
@@ -47,7 +47,7 @@ define(function(require) {
   require('ui/facet').attachTo('#facets');
   require('ui/loading').attachTo('#loading');
   require('ui/filtering').attachTo('#message');
-  require('ui/google_tag_manager').attachTo('#feedback-modal');
+  require('ui/feedback_widget').attachTo('#feedback-modal');
   require('ui/project').attachTo(document);
   require('data/facet').attachTo(document);
   require('data/search').attachTo(document);

--- a/src/templates/welcome.html
+++ b/src/templates/welcome.html
@@ -40,10 +40,10 @@ How to use Get Help Lex
   </p>
 
   <p>
-    Please contact <a href="mailto:gethelplex@lexingtonky.gov?subject=Get Help Lex Feedback">gethelplex@lexingtonky.gov</a> or <a href="tel:8592583834">859-258-3834</a> to report troubleshooting problems with the locator. Please note, this email address is not always monitored and should be used ONLY to report information that needs to be updated and/or revised on the website.
+    Please <a href="#" data-toggle="modal" data-target="#feedback-modal">submit feedback</a> or call <a href="tel:8592583834">859-258-3834</a> to report troubleshooting problems with the locator. Please note, this feedback is not always monitored and should be used ONLY to report information that needs to be updated and/or revised on the website.
   </p>
 
-  <p>DO NOT send treatment, assessment or referral questions to this email address.</p>
+  <p>DO NOT send treatment, assessment or referral questions as feedback.</p>
 </div>
 
 <p><a data-toggle="collapse" href="#glossary" aria-expanded="false" aria-controls="glossary">Types of treatment</a></p>

--- a/src/ui/feedback_widget.js
+++ b/src/ui/feedback_widget.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
     this.addFeedbackToTagManager = function() {
       // track feedback in Google Tag Manager as a backup
       window.dataLayer.push({
-        'eventLabel': this.feedback(),
+        'eventLabel': this.feedback()
       });
     };
 
@@ -31,17 +31,27 @@ define(function(require, exports, module) {
       // see google-apps-feedback-script.js
       $.ajax({
         url: 'https://script.google.com/macros/s/AKfycbzziKocYO7ZmbLvRaSI_OEFSHTVwnCFrTfQT-OzoqAVQvpg1ZE/exec',
-        type: "post",
-        data: {"feedback": this.feedback() },
+        type: 'POST',
+        data: {feedback: this.feedback()},
         success: this.success.bind(this),
         error: this.error.bind(this)
       });
     };
 
-    this.error = function(data) {
+    this.errorAfterSuccessfulMobileSubmit = function(response) {
+      this.success();
+      throw('Error function called after successful mobile submission. Response: ' +
+        JSON.stringify(response) +
+        ', feedback ' + this.feedback());
+    };
+
+    this.error = function(response) {
+      if (response.status === 0 && response.responseText === "") {
+        return this.errorAfterSuccessfulMobileSubmit(response);
+      }
       this.resetSubmitBtn();
       var error = this.$node.find('.js-error');
-      var body = this.feedback() + " (Error details: " + data.responseText + ")";
+      var body = this.feedback() + " \n\n(Error details: " + JSON.stringify(response) + ")";
       error.find('.js-error-email').prop('href', 'mailto:gethelplex@lexingtonky.gov?subject=[GetHelpLex feedback]&body=' + body);
       error.show();
     };

--- a/src/ui/feedback_widget.js
+++ b/src/ui/feedback_widget.js
@@ -16,9 +16,17 @@ define(function(require, exports, module) {
       this.submitBtn().html('Send');
     };
 
+    this.addFeedbackToTagManager = function() {
+      // track feedback in Google Tag Manager as a backup
+      window.dataLayer.push({
+        'eventLabel': this.feedback(),
+      });
+    };
+
     this.handleSubmission = function(e) {
       e.preventDefault();
       this.submitBtn().html('Sending...');
+      this.addFeedbackToTagManager();
 
       // see google-apps-feedback-script.js
       $.ajax({

--- a/src/ui/feedback_widget.js
+++ b/src/ui/feedback_widget.js
@@ -20,7 +20,7 @@ define(function(require, exports, module) {
       e.preventDefault();
       this.submitBtn().html('Sending...');
 
-      // based on https://mashe.hawksey.info/2014/07/google-sheets-as-a-database-insert-with-apps-script-using-postget-methods-with-ajax-example/
+      // see google-apps-feedback-script.js
       $.ajax({
         url: 'https://script.google.com/macros/s/AKfycbzziKocYO7ZmbLvRaSI_OEFSHTVwnCFrTfQT-OzoqAVQvpg1ZE/exec',
         type: "post",

--- a/src/ui/google_tag_manager.js
+++ b/src/ui/google_tag_manager.js
@@ -1,21 +1,49 @@
 define(function(require, exports, module) {
   'use strict';
   var flight = require('flight');
+  var $ = require('jquery');
 
   module.exports = flight.component(function analytics() {
+    this.feedback = function() {
+      return this.$node.find('#feedback-text').val();
+    };
+
+    this.submitBtn = function() {
+      return this.$node.find('.js-submit');
+    };
+
+    this.resetSubmitBtn = function() {
+      this.submitBtn().html('Send');
+    };
+
     this.handleSubmission = function(e) {
       e.preventDefault();
-      window.dataLayer.push({
-        'eventLabel': this.$node.find('#feedback-text').val()
+      this.submitBtn().html('Sending...');
+
+      // based on https://mashe.hawksey.info/2014/07/google-sheets-as-a-database-insert-with-apps-script-using-postget-methods-with-ajax-example/
+      $.ajax({
+        url: 'https://script.google.com/macros/s/AKfycbzziKocYO7ZmbLvRaSI_OEFSHTVwnCFrTfQT-OzoqAVQvpg1ZE/exec',
+        type: "post",
+        data: {"feedback": this.feedback() },
+        success: this.success.bind(this),
+        error: this.error.bind(this)
       });
-      this.success();
+    };
+
+    this.error = function(data) {
+      this.resetSubmitBtn();
+      var error = this.$node.find('.js-error');
+      var body = this.feedback() + " (Error details: " + data.responseText + ")";
+      error.find('.js-error-email').prop('href', 'mailto:gethelplex@lexingtonky.gov?subject=[GetHelpLex feedback]&body=' + body);
+      error.show();
     };
 
     this.success = function() {
-      this.$node.find('.thank-you').show();
+      this.resetSubmitBtn();
+      this.$node.find('.js-thank-you').show();
       setTimeout(function() {
         this.$node.modal('hide');
-        this.$node.find('.thank-you').hide();
+        this.$node.find('.js-thank-you').hide();
       }.bind(this), 2000);
     };
 


### PR DESCRIPTION
Also:
- adds feedback disclaimer with checkbox
- removes the gethelplex email and links to feedback widget instead

Improvements if anyone wants to jump in:
- Put the body of the disclaimer in a template rather than [duplicate it](https://github.com/openlexington/gethelplex/compare/gh-pages...openlexington:feedback-to-spreadsheet?expand=1#diff-eacf331f0ffc35d4b482f1d15a887d3bR150)

Fixes #50 
