### PR TITLE
Collect optional email address from feedback widget

### DIFF
--- a/google-apps-feedback-script.js
+++ b/google-apps-feedback-script.js
@@ -35,7 +35,10 @@ function handleResponse(e) {
   lock.waitLock(30000);  // wait 30 seconds before conceding defeat.
 
   try {
-    MailApp.sendEmail("person@domain.org", "[GetHelpLex feedback]", JSON.stringify(e.parameters));
+    var msg = e.parameters.feedback;
+    if (e.parameters.email) { msg += ', email: ' + e.parameters.email; }
+
+    MailApp.sendEmail("foo@bar.com", "[GetHelpLex feedback]", msg);
 
     // next set where we write the data - you could write to multiple/alternate destinations
     var doc = SpreadsheetApp.openById(SCRIPT_PROP.getProperty("key"));

--- a/index.html
+++ b/index.html
@@ -441,9 +441,9 @@
             </ul>
             <form id="feedback-form" class="form-horizontal" action="#" role="form" method="post">
               <label>Message:</label>
-              <textarea id="feedback-text" class="form-control" required="required" aria-describedby="feedback-label"></textarea>
-              <label>E-Mail:</label>
-              <input class="form-control" type="email" placeholder="user@mydomain.com">
+              <textarea id="feedback-text" class="form-control" name="message" required="required" aria-describedby="feedback-label"></textarea>
+              <label>Email (optional):</label>
+              <input id="feedback-email" class="form-control" type="email" name="email" placeholder="yourname@gmail.com">
               <div>
                 <label><input type="checkbox" required="required"> I have read the
                   <a data-toggle="collapse" href="#feedback-disclaimer" aria-expanded="false" aria-controls="disclaimer">disclaimer</a>

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,11 @@ As a backup, feedback is tracked using the [ga-feedback approach](https://github
 
 Feedback is emailed to addresses defined in the script attached to the [feedback spreadsheet](https://docs.google.com/spreadsheets/d/1lP-OsypwXFkH-S3F3Re34fBPSYgpr1ZXY6bRD85w3V8/edit).
 
+To make changes to the script that handles feedback requests:
+
+* edit in the Appscript editor
+* `Publish` > `Deploy as webapp` > `Version: new`
+
 ## Add map coordinates for new facilities
 
 ![Geocode facilites](./get-help-lex-geocode.gif)

--- a/src/ui/feedback_widget.js
+++ b/src/ui/feedback_widget.js
@@ -5,7 +5,10 @@ define(function(require, exports, module) {
 
   module.exports = flight.component(function analytics() {
     this.feedback = function() {
-      return this.$node.find('#feedback-text').val();
+      return {
+        feedback: this.$node.find('#feedback-text').val(),
+        email: this.$node.find('#feedback-email').val()
+      };
     };
 
     this.submitBtn = function() {
@@ -32,7 +35,7 @@ define(function(require, exports, module) {
       $.ajax({
         url: 'https://script.google.com/macros/s/AKfycbzziKocYO7ZmbLvRaSI_OEFSHTVwnCFrTfQT-OzoqAVQvpg1ZE/exec',
         type: 'POST',
-        data: {feedback: this.feedback()},
+        data: this.feedback(),
         success: this.success.bind(this),
         error: this.error.bind(this)
       });


### PR DESCRIPTION
Manually pull together the email and message to send to Google. It's a brute force approach but will allow us to collect optional email for the moment.
