### PR TITLE
Update print styles to look great when printing from the list view

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -422,6 +422,10 @@ body > div.container {
     padding: 0; 
   }
   
+  #list ul li.item > div > div + div, #list ul li.item > div > div + div + div {
+    border: 0;
+  }
+  
   #map, #finda-tabs, #back-to-top, #gaf-button {
     display: none;
   }

--- a/styles/style.css
+++ b/styles/style.css
@@ -407,4 +407,22 @@ body > div.container {
     content: "Get Help Lex - gethelplex.org";
     font-weight: 900;
   }
+  
+  body > div.container {
+    top: 0;
+  }
+  
+  #list {
+    width: 100%;
+    border: 0;
+  }
+  
+  #list.control > ul > li {
+    border: 0;
+    padding: 0; 
+  }
+  
+  #map, #finda-tabs, #back-to-top, #gaf-button {
+    display: none;
+  }
 }


### PR DESCRIPTION
fixes #115 for real

This makes the list view display correctly when printed. The map is not displayed on a printout. What this does not do is expand all of the items in the list to reveal their full content. It will display nicely the full content of items that are opened manually. Because the full content is added by javascript on demand by the user and since we cant detect when they are printing, this is good as this will get without some significant engineering.... such as keeping the full content actually loaded on the page for each item but hidden unless printed. If that's what we're really looking for, I can make that happen in another PR. :smil

![sketch](https://cloud.githubusercontent.com/assets/40796/17908351/1e8dc9f4-694e-11e6-97c5-6e6bf6aaaf45.png)
