### PR TITLE
Add web_url property assignment to getjson row reader

### DIFF
--- a/src/data/geojson.js
+++ b/src/data/geojson.js
@@ -27,7 +27,8 @@ define(function(require, exports, module) {
         "phone_numbers": csvRow.phone_numbers,
         "address": csvRow.address + " " + csvRow.city + ", Kentucky",
         "city": csvRow.city,
-        "county": csvRow.county
+        "county": csvRow.county,
+        "web_url": csvRow.web_url
       };
 
       _.each(facetValues, function(facet, facetValue) {


### PR DESCRIPTION
I changed the column header in production spreadsheet to match the pattern of the other headers and added a line to use that data as the web_url attribute. The rest just leverages code that was already in place. 

This resolves issue #107 [non-facet data] add website for facilities information.